### PR TITLE
Fix 'Week is done' button

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -96,6 +96,7 @@ class _MainAppState extends State<MainApp> {
   late List<Dish> _dishes;
   DishCategory? _selectedCategory;
   bool _loading = true;
+  final GlobalKey<_WeeksMenuPageState> _weeksMenuKey = GlobalKey<_WeeksMenuPageState>();
 
   @override
   void initState() {
@@ -206,7 +207,7 @@ class _MainAppState extends State<MainApp> {
                 ? const Center(child: CircularProgressIndicator())
                 : TabBarView(
                     children: [
-                      const WeeksMenuPage(),
+                      WeeksMenuPage(key: _weeksMenuKey),
                       Padding(
                         padding: const EdgeInsets.symmetric(horizontal: 16.0),
                         child: Column(
@@ -283,9 +284,7 @@ class _MainAppState extends State<MainApp> {
                           );
                           if (confirmed == true) {
                             // Clear the week
-                            final weeksMenuState = context
-                                .findAncestorStateOfType<_WeeksMenuPageState>();
-                            weeksMenuState?.clearWeek();
+                            _weeksMenuKey.currentState?.clearWeek();
                           }
                         },
                         icon: const Icon(Icons.check),


### PR DESCRIPTION
## Summary
- fix week clearing by passing a GlobalKey to `WeeksMenuPage`
- call `clearWeek` through the key when confirming

## Testing
- `flutter test test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68682af4da148322ac34540ea2665738