### PR TITLE
Fix infinite spinner on week's menu

### DIFF
--- a/lib/dish_storage.dart
+++ b/lib/dish_storage.dart
@@ -49,16 +49,22 @@ class DishStorageWeeksMenu {
     final prefs = await SharedPreferences.getInstance();
     final jsonString = prefs.getString(_weeksMenuKey);
     if (jsonString != null) {
-      final Map<String, dynamic> jsonMap = json.decode(jsonString);
-      return {
-        for (final day in daysOfWeek)
-          day: jsonMap[day] != null
-              ? WeeksMenuEntry.fromJson(jsonMap[day])
-              : WeeksMenuEntry(),
-      };
-    } else {
-      return {for (final day in daysOfWeek) day: WeeksMenuEntry()};
+      try {
+        final decoded = json.decode(jsonString);
+        if (decoded is Map<String, dynamic>) {
+          return {
+            for (final day in daysOfWeek)
+              day: decoded[day] != null
+                  ? WeeksMenuEntry.fromJson(
+                      decoded[day] as Map<String, dynamic>)
+                  : WeeksMenuEntry(),
+          };
+        }
+      } catch (_) {
+        // ignore errors and fall back to default menu
+      }
     }
+    return {for (final day in daysOfWeek) day: WeeksMenuEntry()};
   }
 
   static Future<void> saveWeeksMenu(Map<String, WeeksMenuEntry> menu) async {


### PR DESCRIPTION
## Summary
- add error handling when loading week's menu data

## Testing
- `dart format lib/dish_storage.dart` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687404746a308322adaab52aa2560953